### PR TITLE
Add composer install capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 [![Build Status](https://travis-ci.org/lotsofcode/tag-cloud.png?branch=master)](https://travis-ci.org/lotsofcode/tag-cloud)
 
+#### Install with composer
+
+```bash
+composer require lotsofcode/tag
+```
+
 #### Basic usage
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
+    "name": "lotsofcode/tag-cloud",
+    "type": "library",
+    "description": "PHP tag cloud class http://lotsofcode.github.com/tag-cloud",
+    "keywords": ["tag cloud"],
+    "homepage": "http://lotsofcode.github.com/tag-cloud",
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
For now lotsofcode/tag-cloud is registered with https://github.com/coldwinds/tag-cloud in packagist.org for testing purpose.

I will delete the association when composer can install package with this repo.